### PR TITLE
🦄 feature: Allow for better ESM until v1

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { default } from './lib/tempo';
+export { tempo, tempo as default } from './lib/tempo';
 export { TempoDocument } from './lib/tempo-document';
 export { TempoText } from './lib/tempo-text';
 export {

--- a/src/lib/__tests__/tempo.test.ts
+++ b/src/lib/__tests__/tempo.test.ts
@@ -1,7 +1,7 @@
-import { describe , it, expect } from 'vitest';
+import { describe, it, expect } from 'vitest';
 
 import { TempoDocument } from '../tempo-document';
-import tempo from '../tempo';
+import { tempo } from '../tempo';
 
 describe('tempo', () => {
   it('should return a document', () => {

--- a/src/lib/tempo.ts
+++ b/src/lib/tempo.ts
@@ -37,8 +37,6 @@ import { TempoDocument, type TempoDocumentNode } from './tempo-document';
  * @param documentNodes A list of DocumentNodes to initialize the Document.
  * @returns A new Document instance.
  */
-const tempo = (documentNodes?: TempoDocumentNode[]): TempoDocument => {
+export const tempo = (documentNodes?: TempoDocumentNode[]): TempoDocument => {
   return new TempoDocument(documentNodes);
 };
-
-export default tempo;


### PR DESCRIPTION
### 📗 Description

Better esm support by allowing `import { tempo } from '@joggr/tempo';` vs the default export

### ☑️ Checklist

- [ ] I've labeled the type, i.e. `type: feature` or `type: bugfix`
- [ ] I've labeled the semver, i.e. `semver: major`, `semver: minor` or `semver: patch`
- [ ] This change adds tests for new/changed/fixed functionality & doesn't decrease the test coverage
- [ ] The correct base branch is being used, if not `main`
